### PR TITLE
Updated expense filtering to use enum

### DIFF
--- a/ExpenseTracker/Enums/ExpenseCategory.cs
+++ b/ExpenseTracker/Enums/ExpenseCategory.cs
@@ -1,14 +1,41 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace ExpenseTracker.Enums;
 
 public enum ExpenseCategory
 {
-    Food,
-    Transport,
-    Health,
-    Entertainment,
-    Utilities,
-    Education,
-    Savings,
-    Investments,
-    Miscellaneous
+    // Essentials
+    [Display(Name = "Food")] Food,
+    [Display(Name = "Groceries")] Groceries,
+    [Display(Name = "Housing")] Housing,
+    [Display(Name = "Utilities")] Utilities,
+    [Display(Name = "Phone & Internet")] PhoneAndInternet,
+    [Display(Name = "Transportation")] Transportation,
+    [Display(Name = "Healthcare")] Healthcare,
+
+    // Personal Expenses
+    [Display(Name = "Personal Care")] PersonalCare,
+    [Display(Name = "Entertainment")] Entertainment,
+    [Display(Name = "Shopping")] Shopping,
+    [Display(Name = "Travel")] Travel,
+
+    // Financial
+    [Display(Name = "Savings")] Savings,
+    [Display(Name = "Investments")] Investments,
+    [Display(Name = "Insurance")] Insurance,
+    [Display(Name = "Term Loan Repayment")] TermLoanRepayment,
+    [Display(Name = "Fees")] Fees,
+
+    // Giving & Donations
+    [Display(Name = "Donations")] Donations,
+    [Display(Name = "Gifts")] Gifts,
+
+    // Education & Others
+    [Display(Name = "Education")] Education,
+    [Display(Name = "Betting")] Betting,
+    [Display(Name = "Miscellaneous")] Miscellaneous,
+
+    // Merged from other enum to retain compatibility
+    [Display(Name = "Transport (Legacy)")] Transport,
+    [Display(Name = "Health (Legacy)")] Health,
 }

--- a/ExpenseTracker/Services/ExpenseService.cs
+++ b/ExpenseTracker/Services/ExpenseService.cs
@@ -93,7 +93,7 @@ public class ExpenseService : IExpenseService
         decimal? minAmount = null,
         decimal? maxAmount = null,
         decimal? exactAmount = null,
-        string? category = null)
+        ExpenseCategory? category = null)
     {
         IQueryable<Expense> query = _dbContext.Expenses
             .Where(e => e.UserId == userId);
@@ -125,17 +125,9 @@ public class ExpenseService : IExpenseService
             }
         }
 
-        if (!string.IsNullOrWhiteSpace(category))
+        if (category.HasValue)
         {
-            if (Enum.TryParse<ExpenseCategory>(category, out var parsedCategory))
-            {
-                query = query.Where(e => e.Category == parsedCategory);
-            }
-            else
-            {
-                // If parsing fails, return empty result
-                return new List<Expense>();
-            }
+            query = query.Where(e => e.Category == category.Value);
         }
 
         return await query.OrderByDescending(e => e.DateRecorded).ToListAsync();

--- a/ExpenseTracker/Services/IExpenseService.cs
+++ b/ExpenseTracker/Services/IExpenseService.cs
@@ -1,3 +1,4 @@
+using ExpenseTracker.Enums;
 using ExpenseTracker.Models;
 
 public interface IExpenseService
@@ -11,7 +12,7 @@ public interface IExpenseService
         decimal? minAmount = null,
         decimal? maxAmount = null,
         decimal? exactAmount = null,
-        string? category = null);
+        ExpenseCategory? category = null);
     Task<IEnumerable<Expense>> GetAllExpensesAsync(Guid userId);
     Task<double> GetTotalExpenseAsync(Guid userId, DateTime? startDate, DateTime? endDate, int? month, int? year);
     Task<bool> UpdateExpenseAsync(Guid id, Expense expenseToUpdate, Guid userId);


### PR DESCRIPTION
Update expense filtering to use ExpenseCategory enum instead of string

- Replace string category parameter with ExpenseCategory enum in controller and service
- Add ExpenseTracker.Enums using statement to ExpenseController
- Expand ExpenseCategory enum with additional categories and display names
- Remove string parsing logic from GetFilteredExpensesAsync method
- Update IExpenseService interface to use ExpenseCategory enum
- Add custom validation error handling in Program.cs