### PR TITLE
Optimize enum options retrieval in metadata service

### DIFF
--- a/ExpenseTracker/Controllers/MetadataController.cs
+++ b/ExpenseTracker/Controllers/MetadataController.cs
@@ -1,4 +1,3 @@
-using ExpenseTracker.Enums;
 using ExpenseTracker.Models;
 using ExpenseTracker.Models.DTOs.Metadata;
 using ExpenseTracker.Services;
@@ -27,8 +26,7 @@ public class MetadataController(IMetadataService enumService) : ControllerBase
 	[ProducesResponseType(typeof(ApiResponse<List<EnumOptionResponse>>), StatusCodes.Status200OK)]
 	public ActionResult<ApiResponse<List<EnumOptionResponse>>> GetExpenseCategories()
 	{
-		List<EnumOptionResponse> result = _enumService.GetExpenseCategories();
-		return Ok(ApiResponse<List<EnumOptionResponse>>.Ok(result));
+		return Ok(ApiResponse<List<EnumOptionResponse>>.Ok(_enumService.GetExpenseCategories()));
 	}
 
 	/// <summary>
@@ -43,8 +41,7 @@ public class MetadataController(IMetadataService enumService) : ControllerBase
 	[ProducesResponseType(typeof(ApiResponse<List<EnumOptionResponse>>), StatusCodes.Status200OK)]
 	public ActionResult<ApiResponse<List<EnumOptionResponse>>> GetPaymentMethods()
 	{
-		List<EnumOptionResponse> result = _enumService.GetPaymentMethods();
-		return Ok(ApiResponse<List<EnumOptionResponse>>.Ok(result));
+		return Ok(ApiResponse<List<EnumOptionResponse>>.Ok(_enumService.GetPaymentMethods()));
 	}
 
 	/// <summary>
@@ -59,7 +56,6 @@ public class MetadataController(IMetadataService enumService) : ControllerBase
 	[ProducesResponseType(typeof(ApiResponse<List<EnumOptionResponse>>), StatusCodes.Status200OK)]
 	public ActionResult<ApiResponse<List<EnumOptionResponse>>> GetSavingGoalStatuses()
 	{
-		List<EnumOptionResponse> result = _enumService.GetSavingGoalStatuses();
-		return Ok(ApiResponse<List<EnumOptionResponse>>.Ok(result));
+		return Ok(ApiResponse<List<EnumOptionResponse>>.Ok(_enumService.GetSavingGoalStatuses()));
 	}
 }

--- a/ExpenseTracker/Services/MetaDataService.cs
+++ b/ExpenseTracker/Services/MetaDataService.cs
@@ -10,21 +10,36 @@ namespace ExpenseTracker.Services;
 /// </summary>
 internal class MetadataService : IMetadataService
 {
-	private static List<EnumOptionResponse> GetEnumOptions<T>() where T : Enum
+	private static readonly List<EnumOptionResponse> ExpenseCategoriesCache = BuildEnumOptions<ExpenseCategory>();
+	private static readonly List<EnumOptionResponse> PaymentMethodsCache = BuildEnumOptions<PaymentMethod>();
+	private static readonly List<EnumOptionResponse> SavingGoalStatusesCache = BuildEnumOptions<SavingGoalStatus>();
+
+	private static List<EnumOptionResponse> BuildEnumOptions<T>() where T : Enum
 	{
-		return [.. Enum.GetValues(typeof(T))
-			.Cast<T>()
-			.Select(e => new EnumOptionResponse
+		Type type = typeof(T);
+		Array values = Enum.GetValues(type);
+		List<EnumOptionResponse> result = new(values.Length);
+
+		foreach (object value in values)
+		{
+			string name = value.ToString()!;
+
+			string label = type
+				.GetMember(name)[0]
+				.GetCustomAttribute<DisplayAttribute>()?.Name ?? name;
+
+			result.Add(new EnumOptionResponse
 			{
-				Value = e.ToString(),
-				Label = e.GetType()
-					.GetMember(e.ToString())
-					.First()
-					.GetCustomAttribute<DisplayAttribute>()?.Name ?? e.ToString()
-			})];
+				Value = name,
+				Label = label
+			});
+		}
+
+		return result;
 	}
 
-	public List<EnumOptionResponse> GetExpenseCategories() => GetEnumOptions<ExpenseCategory>();
-	public List<EnumOptionResponse> GetPaymentMethods() => GetEnumOptions<PaymentMethod>();
-	public List<EnumOptionResponse> GetSavingGoalStatuses() => GetEnumOptions<SavingGoalStatus>();
+	public List<EnumOptionResponse> GetExpenseCategories() => ExpenseCategoriesCache;
+	public List<EnumOptionResponse> GetPaymentMethods() => PaymentMethodsCache;
+	public List<EnumOptionResponse> GetSavingGoalStatuses() => SavingGoalStatusesCache;
 }
+


### PR DESCRIPTION
- Refactored MetadataService to cache enum option lists for expense categories, payment methods, and saving goal statuses, improving performance by avoiding repeated reflection.
- Controller methods simplified to return results directly from the service.